### PR TITLE
🐛 CurrencyWon에 forwardRef 추가하여 React.forwardRef() 에러 수정

### DIFF
--- a/components/ui/currencyInputWon.tsx
+++ b/components/ui/currencyInputWon.tsx
@@ -1,21 +1,29 @@
 import { NumericFormat } from "react-number-format";
 import { Input } from "./input";
+import { forwardRef } from "react";
 
-export default function CurrencyWon({
-  displayType = "input",
-  ...props
-}: {
-  [x: string]: any;
-  displayType?: "input" | "text";
-}) {
-  return (
-    <NumericFormat
-      className="bg-inherit"
-      customInput={Input}
-      thousandSeparator
-      {...props}
-      suffix={"원"}
-      displayType={displayType}
-    />
-  );
-}
+const CurrencyWon = forwardRef(
+  (
+    {
+      displayType = "input",
+      ...props
+    }: {
+      [x: string]: any;
+      displayType?: "input" | "text";
+    },
+    ref
+  ) => {
+    return (
+      <NumericFormat
+        className="bg-inherit"
+        customInput={Input}
+        thousandSeparator
+        {...props}
+        suffix={"원"}
+        displayType={displayType}
+      />
+    );
+  }
+);
+
+export default CurrencyWon;


### PR DESCRIPTION
부모 컴포넌트에서 자식 컴포넌트의 DOM 요소를 접근할 때는 forwardRef를 사용하여 접근해야 한다고 한다.
CurrencyWon 컴포넌트에서 발생하는 에러 같아 forwardRef로 감싸주니 에러는 더 이상 안찍힌다.
하지만 ref 파라미터가 사용되지 않고 있고, 왜 ref 접근이 발생하고 있는지를 모르겠다.

Close #20 